### PR TITLE
fix(adf): make adf init --module additive when .ai/ exists

### DIFF
--- a/packages/cli/src/commands/adf.ts
+++ b/packages/cli/src/commands/adf.ts
@@ -176,7 +176,18 @@ Do not duplicate rules from .ai/ modules into this file or other agent config fi
 function adfInit(options: CLIOptions, args: string[]): number {
   const force = options.yes || args.includes('--force');
   const aiDir = getFlag(args, '--ai-dir') || '.ai';
+  const moduleFlag = getFlag(args, '--module');
   const manifestPath = path.join(aiDir, 'manifest.adf');
+
+  // --module: additive single-module creation — delegate to adf create
+  if (moduleFlag) {
+    if (!fs.existsSync(manifestPath)) {
+      throw new CLIError(
+        `manifest.adf not found at ${manifestPath}. Run 'charter adf init' first to scaffold .ai/.`
+      );
+    }
+    return adfCreate(options, [moduleFlag, '--ai-dir', aiDir]);
+  }
 
   if (fs.existsSync(manifestPath) && !force) {
     const result: AdfInitResult = { created: false, aiDir, files: [] };
@@ -185,6 +196,7 @@ function adfInit(options: CLIOptions, args: string[]): number {
     } else {
       console.log(`  .ai/ already exists at ${aiDir}/`);
       console.log('  Use --force (or --yes) to overwrite.');
+      console.log('  To add a single module: charter adf init --module <name>');
     }
     return EXIT_CODE.SUCCESS;
   }
@@ -495,6 +507,7 @@ function printHelp(): void {
   console.log('  Usage:');
   console.log('    charter adf init [--ai-dir <dir>] [--force] [--emit-pointers]');
   console.log('      Scaffold .ai/ directory with manifest, core, and state modules.');
+  console.log('      --module <name>: add a single module to an existing .ai/ (additive, no overwrite)');
   console.log('      --emit-pointers: also generate thin pointer files (CLAUDE.md, .cursorrules, agents.md)');
   console.log('');
   console.log('    charter adf fmt <file> [--check] [--write]');


### PR DESCRIPTION
## Summary

- When `--module <name>` is passed to `adf init` and `.ai/` already exists, delegate to `adf create` to scaffold only the specified module and register it in `ON_DEMAND`
- No other files are touched — `core.adf`, `state.adf`, `manifest.adf` remain as-is
- When `.ai/` doesn't exist, errors with a clear message pointing to `charter adf init`
- Added `--module` to the "already exists" hint message and help text

Previously:
- Without `--yes`: failed with "already exists" error
- With `--yes`: regenerated all scaffold files, potentially losing customizations

Closes #5

## Test plan

- [ ] `charter adf init` on clean project → scaffolds all files (unchanged behavior)
- [ ] `charter adf init --module logging` on existing `.ai/` → creates only `logging.adf`, registers in manifest
- [ ] `charter adf init --module frontend` on existing `.ai/` with `frontend.adf` → reports already exists/registered
- [ ] `charter adf init --module infra` without `.ai/` → clear error message
- [ ] All 200 existing tests pass, LOC ceiling at 590/650

🤖 Generated with [Claude Code](https://claude.com/claude-code)