### PR TITLE
fix(security): remove shell injection surface and block directory traversal

### DIFF
--- a/packages/cli/src/commands/adf.ts
+++ b/packages/cli/src/commands/adf.ts
@@ -480,7 +480,19 @@ function adfCreate(options: CLIOptions, args: string[]): number {
 
   const modulePath = moduleArg.endsWith('.adf') ? moduleArg : `${moduleArg}.adf`;
   const moduleRelPath = modulePath.replace(/\\/g, '/');
+
+  // Prevent directory traversal: reject paths that escape the .ai/ directory
+  if (moduleRelPath.includes('..') || path.isAbsolute(moduleRelPath)) {
+    throw new CLIError(`Invalid module path: "${moduleRelPath}". Path must not contain ".." or be absolute.`);
+  }
+
   const moduleAbsPath = path.join(aiDir, moduleRelPath);
+  const resolvedAiDir = path.resolve(aiDir);
+  const resolvedModulePath = path.resolve(moduleAbsPath);
+  if (!resolvedModulePath.startsWith(resolvedAiDir + path.sep)) {
+    throw new CLIError(`Invalid module path: "${moduleRelPath}". Path must stay within ${aiDir}/.`);
+  }
+
   fs.mkdirSync(path.dirname(moduleAbsPath), { recursive: true });
 
   let fileCreated = false;

--- a/packages/cli/src/git-helpers.ts
+++ b/packages/cli/src/git-helpers.ts
@@ -1,9 +1,9 @@
 /**
  * Shared git invocation helpers.
  *
- * Centralizes all child-process git calls behind a single `runGit()` that
- * uses `shell: true` for cross-platform PATH resolution (fixes WSL, CMD,
- * PowerShell parity — see ADX-005 F2).
+ * Centralizes all child-process git calls behind a single `runGit()`.
+ * All args are hardcoded call-site strings, never user input — but we
+ * still avoid `shell: true` to eliminate any shell-injection surface.
  */
 
 import { execFileSync } from 'node:child_process';
@@ -16,17 +16,16 @@ import type { GitCommit } from '@stackbilt/types';
 /**
  * Run a git command and return its stdout.
  *
- * Uses `shell: true` so that the OS shell resolves the `git` binary via
- * PATH.  This is the key cross-platform fix: `execFileSync` *without* a
- * shell can fail on WSL/Windows when git lives in a PATH entry the Node
- * process doesn't see directly.
+ * Does NOT use `shell: true` — Node resolves `git` via PATH directly, which
+ * works on WSL, Linux, macOS, and Windows (Git for Windows adds git to PATH
+ * at install time). Using shell: true is unnecessary here and would allow
+ * shell metacharacters in args to be interpreted as shell syntax.
  */
 export function runGit(args: string[]): string {
   return execFileSync('git', args, {
     encoding: 'utf-8',
     stdio: ['ignore', 'pipe', 'pipe'],
     maxBuffer: 10 * 1024 * 1024,
-    shell: true,
   });
 }
 


### PR DESCRIPTION
## Summary

Two targeted security fixes with no functional behavior change for valid inputs.

- **#43 — `shell: true` in git operations (HIGH):** Removed `shell: true` from `runGit()` in `git-helpers.ts`. Node.js resolves the `git` binary via PATH directly on WSL, Linux, macOS, and Windows without needing a shell. The flag was a historical cross-platform workaround that is no longer necessary and creates a surface where shell metacharacters in args could be interpreted as shell syntax.

- **#42 — Directory traversal in `adf create` (HIGH):** User-supplied module names are now validated before `path.join`. Paths containing `..` or absolute paths are rejected immediately. A secondary resolved-path check confirms the final path stays within `aiDir`, guarding against platform-specific bypass patterns (e.g. URL-encoded separators).

## Test plan

- [ ] `charter adf create ../../../etc/passwd` → rejected with clear error
- [ ] `charter adf create /absolute/path` → rejected with clear error
- [ ] `charter adf create my-module` → works as before
- [ ] `charter adf create subdir/my-module` → works as before
- [ ] All 272 existing tests pass
- [ ] `runGit()` still resolves git correctly on WSL (PATH-based resolution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)