### PR TITLE
[auto] [Issue #59] Suppress release.yml false-failure notifications

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - 'v*'
+    branches-ignore:
+      - '**'
   workflow_dispatch:
     inputs:
       tag:

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ C:*
 node_modules/
 .pnpm-store/
 __pycache__/
+# cc-taskrunner worktree protection
+C:*
+node_modules/
+.pnpm-store/
+__pycache__/


### PR DESCRIPTION
## Autonomous Task

**Task ID**: `f065fbe2-7290-4445-8b3e-040decbdbf5d`
**Authority**: auto_safe
**Exit code**: 0

## Task Prompt
## Problem

The `release.yml` GitHub Actions workflow triggers on `push: tags: v*` but GitHub evaluates the workflow on every push to main. When no tag matches, it reports "no jobs were run" which GitHub treats as a failure — sending a notification email every commit.

## What to Fix

In `.github/workflows/release.yml`, the current trigger is:
```yaml
on:
  push:
    tags:
      - 'v*'
  workflow_dispatch:
```

Add `branches-ignore` to prevent evaluation on non-tag pushes:
```yaml
on:
  push:
    tags:
      - 'v*'
    branches-ignore:
      - '**'
  workflow_dispatch:
```

This keeps tag-triggered releases and manual dispatch while suppressing the false-failure on regular pushes.

## Constraints
- Do NOT change the release logic itself
- Do NOT remove the workflow_dispatch trigger
- Verify the YAML is valid after editing

Commit your work. TASK_COMPLETE when done.

## Result Summary
TASK_COMPLETE

---
Generated by AEGIS task runner. Review before merging.