### PR TITLE
[auto] OSS standardization: charter — verify license + branding footer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,8 @@ C:*
 node_modules/
 .pnpm-store/
 __pycache__/
+# cc-taskrunner worktree protection
+C:*
+node_modules/
+.pnpm-store/
+__pycache__/

--- a/LICENSE
+++ b/LICENSE
@@ -175,7 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2026 StackBilt, Smart Brand Strategies LLC
+   Copyright 2026 Stackbilt LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -416,6 +416,10 @@ The [`papers/`](./papers/) directory contains Charter's research narrative:
 
 Apache-2.0. See [LICENSE](./LICENSE).
 
+---
+
+Built by [Stackbilt](https://stackbilt.dev) — Apache-2.0 License
+
 <p>
   <a href="https://www.buymeacoffee.com/kurto" target="_blank" rel="noopener noreferrer">
     <img src="https://img.shields.io/badge/Buy%20me%20a%20coffee-5F7FFF?style=for-the-badge&logo=buymeacoffee&logoColor=FFDD00" alt="Buy me a coffee" />

--- a/package.json
+++ b/package.json
@@ -43,5 +43,7 @@
     "vitest": "^4.0.18",
     "zod": "^3.24.1"
   },
-  "version": "0.9.3"
+  "version": "0.9.3",
+  "license": "Apache-2.0",
+  "author": "Stackbilt LLC"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,5 +48,6 @@
     "@stackbilt/types": "workspace:^",
     "@stackbilt/validate": "workspace:^"
   },
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "author": "Stackbilt LLC"
 }


### PR DESCRIPTION
## Autonomous Task

**Task ID**: `3bfbd5f1-d7df-44dc-8a5f-79a2f32973b6`
**Authority**: auto_safe
**Exit code**: 0

## Task Prompt
## Mission
Verify and standardize branding on this public OSS repo.

## Checklist

### 1. LICENSE file
Verify Apache-2.0 LICENSE exists with "Stackbilt LLC" as copyright holder.

### 2. README footer
Ensure README.md ends with a consistent Stackbilt footer. It currently has a Buy Me a Coffee badge — keep that, but ensure "Built by Stackbilt" is also present:
```markdown
---

Built by [Stackbilt](https://stackbilt.dev) — Apache-2.0 License

<p>
  <a href="https://www.buymeacoffee.com/kurto" target="_blank" rel="noopener noreferrer">
    <img src="https://img.shields.io/badge/Buy%20me%20a%20coffee-5F7FFF?style=for-the-badge&logo=buymeacoffee&logoColor=FFDD00" alt="Buy me a coffee" />
  </a>
</p>
```

### 3. package.json (root + packages/cli)
Ensure `"license": "Apache-2.0"` and `"author": "Stackbilt LLC"` in both root package.json and packages/cli/package.json.

## Constraints
- Banner already exists — do NOT replace it
- Do NOT change README content above the footer
- Quick pass

Commit your work. TASK_COMPLETE when done.

## Result Summary
All four items verified and updated:

1. **LICENSE** — Copyright holder corrected to "Stackbilt LLC"
2. **README.md** — Added "Built by Stackbilt" footer with separator, kept existing Buy Me a Coffee badge
3. **Root package.json** — Added `"license": "Apache-2.0"` and `"author": "Stackbilt LLC"`
4. **packages/cli/package.json** — Added `"author": "Stackbilt LLC"` (license was already correct)

TASK_COMPLETE

---
Generated by AEGIS task runner. Review before merging.