### PR TITLE
fix(cli,blast): accept ea_ key prefix + exclude .claude/ from graph scan

### DIFF
--- a/packages/blast/src/index.ts
+++ b/packages/blast/src/index.ts
@@ -76,6 +76,7 @@ const DEFAULT_IGNORE_DIRS = new Set([
   '.cache',
   'coverage',
   '.wrangler',
+  '.claude',
 ]);
 
 // Matches: import X from '...', import { X } from '...', import '...', export ... from '...', require('...')

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -29,16 +29,20 @@ export async function loginCommand(options: CLIOptions, args: string[]): Promise
     } else {
       console.log('Not logged in.');
       console.log('');
-      console.log('Usage: charter login --key sb_live_xxx');
+      console.log('Usage: charter login --key ea_xxx');
+      console.log('       charter login --key sb_live_xxx');
       console.log('       charter login --key sb_test_xxx');
       console.log('');
-      console.log('Get your API key from the Stackbilt dashboard.');
+      console.log('Get your API key from auth.stackbilt.dev (ea_) or the Stackbilt dashboard (sb_).');
     }
     return EXIT_CODE.SUCCESS;
   }
 
-  if (!key.startsWith('sb_live_') && !key.startsWith('sb_test_')) {
-    throw new CLIError('Invalid API key format. Keys must start with sb_live_ or sb_test_.');
+  const VALID_PREFIXES = ['ea_', 'sb_live_', 'sb_test_'];
+  if (!VALID_PREFIXES.some((p) => key.startsWith(p))) {
+    throw new CLIError(
+      `Invalid API key format. Keys must start with one of: ${VALID_PREFIXES.join(', ')}.`
+    );
   }
 
   const baseUrl = getFlag(args, '--url');


### PR DESCRIPTION
## Summary
- **charter login**: Accept \`ea_\` prefix alongside \`sb_live_\`/\`sb_test_\`. Runtime already accepts edge-auth keys; the CLI validator was stale. Same class as mcp-gateway#28.
- **@stackbilt/blast**: Add \`.claude\` to \`DEFAULT_IGNORE_DIRS\`. Claude Code worktrees under \`.claude/worktrees/agent-*/\` are bit-identical copies of canonical source and pollute \`hotFiles\` with ghost duplicates.

## Test plan
- [ ] \`charter login --key ea_RqB-yrk8...\` succeeds (smoke-tested with live engine)
- [ ] \`charter blast <seed> --format json\` no longer shows duplicate \`.claude/worktrees/...\` entries in hotFiles on a repo with active worktrees
- [ ] Existing \`sb_live_\`/\`sb_test_\` keys still work

Closes #98
Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)