### PR TITLE
ci(release): publish to npm on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,3 +92,50 @@ jobs:
           name: ${{ steps.tag.outputs.value }}
           body_path: release_notes.md
           generate_release_notes: true
+
+  publish-npm:
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.tag || github.ref }}
+
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Verify workspace versions match tag
+        shell: bash
+        run: |
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          EXPECTED="${TAG#v}"
+          FAIL=0
+          for p in packages/*/package.json; do
+            V=$(node -p "require('./$p').version")
+            N=$(node -p "require('./$p').name")
+            if [[ "$V" != "$EXPECTED" ]]; then
+              echo "::error::$N version $V does not match tag $EXPECTED"
+              FAIL=1
+            fi
+          done
+          if [[ $FAIL -ne 0 ]]; then exit 1; fi
+
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: pnpm -r publish --access public --no-git-checks --provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,6 +119,7 @@ jobs:
       - name: Build
         run: pnpm run build
 
+      # Enforces unified workspace versioning — every packages/*/package.json must match the tag.
       - name: Verify workspace versions match tag
         shell: bash
         run: |


### PR DESCRIPTION
## Summary

- Closes the supply-chain gap between GitHub releases and npm publishes. The `Release` workflow has only ever created a GitHub Release tag — npm publishes were done manually from a maintainer workstation and stopped landing after v0.10.0 (2026-04-09). v0.11.0 tagged 2026-04-16 but never made it to npm; all 11 `@stackbilt/*` packages still show `0.10.0`.
- Adds a `publish-npm` job running `pnpm -r publish --access public --no-git-checks --provenance` on tag push (and `workflow_dispatch` for backfill). Parallel to the existing `publish-release` job — neither blocks the other on failure.
- **Version-sync guard:** iterates every `packages/*/package.json`; fails the workflow before any publish call if any package version ≠ tag. Catches half-bumped release PRs.
- **Provenance:** `--provenance` + `id-token: write` permission links each npm tarball to this GHA run via a cryptographic attestation. Reasonable supply-chain hygiene for an OSS governance package.

## Prerequisites

- `NPM_TOKEN` repo (or org) secret exists with publish access on `@stackbilt/*`. Confirmed externally; not set in this PR.

## Test plan

- [ ] Merge this PR.
- [ ] Dry-run via workflow_dispatch: `gh workflow run release.yml -f tag=v0.11.0`.
  - `pnpm -r publish` is idempotent on already-published versions, so already-shipped 0.10.0 packages no-op and 0.11.0-tagged packages ship.
- [ ] `npm view @stackbilt/cli version` returns `0.11.0` (and same for the other 10 workspace packages).
- [ ] Each package's npm page shows a "Provenance" badge linking back to this repo + the GHA run.
- [ ] Future tag pushes (e.g. v0.11.1 or v0.12.0) publish automatically without manual intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)