### PR TITLE
ci(release): swap pnpm for npm for trusted-publisher OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,4 +139,4 @@ jobs:
       - name: Publish to npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: pnpm -r publish --access public --no-git-checks --provenance
+        run: npm publish --workspaces --access public --provenance


### PR DESCRIPTION
## Summary

- v0.12.0 tag push failed at `publish-npm` with `E404` on `@stackbilt/adf` — npm's stealth 404 for trusted-publisher auth rejection. Trusted-publisher config on all 11 packages verified identical (Org `Stackbilt-dev`, Repo `charter`, Workflow `release.yml`, Env blank).
- Root cause hypothesis: **pnpm 9's `--provenance` signs attestations via OIDC but still authenticates the publish request with `NODE_AUTH_TOKEN`.** When a package has a trusted publisher configured, npm may require the publish auth itself to be OIDC-based — and rejects token auth with a 404.
- npm CLI (10+, bundled with `actions/setup-node@v6.3.0`) has first-class trusted-publisher OIDC support: `npm publish --provenance` does the full OIDC-based publish auth that trusted publishers expect.
- One-line swap: `pnpm -r publish --access public --no-git-checks --provenance` → `npm publish --workspaces --access public --provenance`.

## Why `npm publish --workspaces` works

Root `package.json` declares `"workspaces": ["packages/*"]`, so `npm publish --workspaces` iterates every non-private workspace and publishes each. All 11 `@stackbilt/*` packages have `"private": false` + `"publishConfig": { "access": "public" }`.

`NODE_AUTH_TOKEN` env retained as belt-and-braces in case any package doesn't yet have a trusted publisher — harmless otherwise.

## Test plan

- [ ] Merge this PR.
- [ ] Re-dispatch existing tag: `gh workflow run release.yml -f tag=v0.12.0`. Idempotent — no 0.12.0 tarballs have shipped yet.
- [ ] Verify all 11 `@stackbilt/*` packages at 0.12.0 on npm.
- [ ] Verify the Provenance badge on each package's npmjs.com page.
- [ ] If the same 404 appears, pivot to shipping without provenance (drop `--provenance` as a hotfix) — trusted-publisher config has a deeper issue beyond the three visible UI fields.

## Related

- Follows #118 (original publish automation).
- Unblocks v0.12.0 release (currently tagged but unpublished to npm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)