### PR TITLE
ci(release): drop token plumbing — OIDC trusted publishers only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,11 +107,13 @@ jobs:
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
+      # No registry-url: setup-node would otherwise write ~/.npmrc with a
+      # _authToken line, which makes npm CLI prefer token auth over the
+      # OIDC flow that trusted publishers require.
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: '20'
           cache: 'pnpm'
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -136,7 +138,7 @@ jobs:
           done
           if [[ $FAIL -ne 0 ]]; then exit 1; fi
 
+      # Auth is OIDC via npm trusted publishers — no NPM_TOKEN needed.
+      # See: https://docs.npmjs.com/trusted-publishers
       - name: Publish to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --workspaces --access public --provenance


### PR DESCRIPTION
## Summary

Root cause found for the v0.12.0 `E404` on `@stackbilt/adf`: the workflow's token plumbing was short-circuiting the OIDC flow that trusted publishers require.

- `actions/setup-node`'s `registry-url: 'https://registry.npmjs.org'` option writes `~/.npmrc` with `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`.
- npm CLI sees that config and uses token auth for the publish PUT — **even with `--provenance` and trusted publishers configured on every package**.
- With `NPM_TOKEN` now revoked at the account level (per trusted-publisher migration), the token string is a dead value. npm's stealth 404 for unauthorized writes is what we've been seeing.

## Change

Two deletions from `.github/workflows/release.yml`:

1. `registry-url: 'https://registry.npmjs.org'` removed from `actions/setup-node` — stops `.npmrc` generation.
2. `env: NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` removed from the "Publish to npm" step — nothing reads it.

With both gone, npm CLI sees `id-token: write` + `--provenance` + trusted publisher configured per package, and uses OIDC for **both** provenance signing AND publish auth. This is the end-state trusted publishers are designed for.

## Why this is the right fix (not "regenerate the token")

Trusted publishers exist specifically to eliminate long-lived tokens from CI. Keeping the token plumbing as belt-and-braces was defensive but actively harmful here — `.npmrc`'s `_authToken` takes precedence over OIDC regardless of `--provenance`.

## Test plan

- [ ] Merge.
- [ ] `gh workflow run release.yml -f tag=v0.12.0` — idempotent, nothing published yet for 0.12.0.
- [ ] All 11 `@stackbilt/*` packages publish via OIDC at 0.12.0.
- [ ] Provenance badge appears on each package's npmjs.com page.
- [ ] Follow-up PR: delete the now-unused `NPM_TOKEN` repo secret via `gh secret delete NPM_TOKEN --repo Stackbilt-dev/charter`.

## Related

- Follows #118 (original publish automation), #119 (pnpm→npm swap). The swap in #119 turned out to be necessary but not sufficient — `npm publish --provenance` still needed the `.npmrc` to be absent.
- Unblocks v0.12.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)