### PR TITLE
ci(release): upgrade npm to 11+ for trusted-publisher OIDC auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,11 @@ jobs:
           node-version: '20'
           cache: 'pnpm'
 
+      # npm 11.5.1+ required for trusted-publisher OIDC auth on publish.
+      # The version bundled with Node 20 on setup-node is ~10.x.
+      - name: Upgrade npm for trusted-publisher support
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Summary

#120 removed the token plumbing expecting npm's `--provenance` flag to drive OIDC-based publish auth. It doesn't — `--provenance` only signs attestations via OIDC. **Publish auth via OIDC for trusted publishers requires npm 11.5.1+**, which is newer than what setup-node bundles with Node 20 (currently ~10.x).

Result on the v0.12.0 retry: `ENEEDAUTH` — the CLI had no token (correct end state after #120) but didn't know how to use OIDC for auth.

## Change

Add `npm install -g npm@latest` as a step before dependency install. npm 11.12.1 as of 2026-04-18 has first-class trusted-publisher OIDC auth.

## Test plan

- [ ] Merge.
- [ ] `gh workflow run release.yml -f tag=v0.12.0` — idempotent, nothing published yet for 0.12.0.
- [ ] All 11 `@stackbilt/*` packages publish via OIDC at 0.12.0.
- [ ] Provenance badge appears on each package's npmjs.com page.
- [ ] Follow-up: delete unused `NPM_TOKEN` repo secret.

## History

- #118 added initial publish automation (token-based).
- #119 swapped pnpm → npm for first-class trusted-publisher support in the CLI.
- #120 removed token plumbing to let OIDC take over — but the Node-20-bundled npm was too old to actually do OIDC publish auth.
- **This PR** gets the CLI to a version that supports the flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)