### PR TITLE
[codex] Add security-sensitive bootstrap mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Claude Code can query `getProjectContext`, `getArchitecturalDecisions`, `getProj
 ```bash
 charter                                  # Repo risk/value snapshot
 charter bootstrap --ci github            # One-command onboarding
+charter bootstrap --security-sensitive   # SECURITY.md + hard security drift denies
 charter doctor                           # Environment/config health check
 charter validate                         # Commit governance (trailers)
 charter drift                            # Pattern drift scanning

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -78,11 +78,13 @@ One-command repo onboarding. Orchestrates detect + setup + ADF init + install + 
 ```bash
 npx charter bootstrap                                         # interactive
 npx charter bootstrap --preset worker --ci github --yes       # fully automated
+npx charter bootstrap --preset worker --security-sensitive     # security posture baseline
 npx charter bootstrap --skip-install --skip-doctor            # minimal
 ```
 
 - `--ci github` — generate GitHub Actions governance workflow
 - `--preset <worker|frontend|backend|fullstack|docs>` — stack preset
+- `--security-sensitive` — generate `SECURITY.md`, seed hard-fail drift denies in `.charter/patterns/security-deny.json`, and warn in `doctor` when no `security*` or `l4*` test file exists
 - `--skip-install` — skip dependency installation phase
 - `--skip-doctor` — skip health check phase
 - `-y, --yes` — accept all prompts

--- a/packages/cli/src/__tests__/bootstrap.test.ts
+++ b/packages/cli/src/__tests__/bootstrap.test.ts
@@ -3,6 +3,8 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { bootstrapCommand } from '../commands/bootstrap';
+import { doctorCommand } from '../commands/doctor';
+import { driftCommand } from '../commands/drift';
 import type { CLIOptions } from '../index';
 
 const baseOptions: CLIOptions = {
@@ -121,5 +123,51 @@ STATE:
     const manifest = fs.readFileSync(path.join('.ai', 'manifest.adf'), 'utf-8');
     expect(manifest).toContain('agent.adf');
     expect(manifest).toContain('persona.adf');
+  });
+
+  it('seeds security-sensitive bootstrap files and warns when security tests are absent', async () => {
+    const exitCode = await bootstrapCommand(
+      { ...baseOptions, yes: true },
+      ['--yes', '--preset', 'worker', '--security-sensitive', '--skip-install', '--skip-doctor'],
+    );
+
+    expect(exitCode).toBe(0);
+    expect(fs.existsSync('SECURITY.md')).toBe(true);
+    expect(fs.existsSync(path.join('.charter', 'patterns', 'security-deny.json'))).toBe(true);
+
+    logs = [];
+    await doctorCommand({ ...baseOptions, format: 'json' }, []);
+    const report = JSON.parse(logs[0]);
+    const securityCheck = report.checks.find((check: { name: string }) => check.name === 'security test coverage');
+    expect(securityCheck.status).toBe('WARN');
+
+    fs.mkdirSync('tests', { recursive: true });
+    fs.writeFileSync(path.join('tests', 'security-l4.test.ts'), 'export {};');
+
+    logs = [];
+    await doctorCommand({ ...baseOptions, format: 'json' }, []);
+    const updatedReport = JSON.parse(logs[0]);
+    const updatedSecurityCheck = updatedReport.checks.find((check: { name: string }) => check.name === 'security test coverage');
+    expect(updatedSecurityCheck.status).toBe('PASS');
+  });
+
+  it('treats security deny drift matches as CI policy violations', async () => {
+    await bootstrapCommand(
+      { ...baseOptions, yes: true },
+      ['--yes', '--preset', 'worker', '--security-sensitive', '--skip-install', '--skip-doctor'],
+    );
+    fs.mkdirSync('src', { recursive: true });
+    fs.writeFileSync(path.join('src', 'verify.ts'), 'export function verify(computed: string, signature: string) { return computed === signature; }\n');
+
+    logs = [];
+    const exitCode = await driftCommand({ ...baseOptions, format: 'json', ciMode: true }, ['--path', '.']);
+    const report = JSON.parse(logs[0]);
+
+    expect(exitCode).toBe(1);
+    expect(report.status).toBe('FAIL');
+    expect(report.securityBlockers).toBeGreaterThan(0);
+    expect(report.violations.some((violation: { severity: string; patternName: string }) =>
+      violation.severity === 'BLOCKER' && violation.patternName.includes('Timing-Sensitive Equality')
+    )).toBe(true);
   });
 });

--- a/packages/cli/src/commands/bootstrap.ts
+++ b/packages/cli/src/commands/bootstrap.ts
@@ -79,6 +79,7 @@ export async function bootstrapCommand(options: CLIOptions, args: string[]): Pro
   const skipInstall = args.includes('--skip-install');
   const skipDoctor = args.includes('--skip-doctor');
   const force = args.includes('--force');
+  const securitySensitive = args.includes('--security-sensitive');
   const nonInteractive = options.yes;
   const setupOverwrite = options.yes || force;
 
@@ -125,7 +126,7 @@ export async function bootstrapCommand(options: CLIOptions, args: string[]): Pro
   // ========================================================================
   // Phase 2: Setup
   // ========================================================================
-  const setupResult = runSetupPhase(options, selectedPreset, detection, contexts, ciTarget, packageManager, setupOverwrite);
+  const setupResult = runSetupPhase(options, selectedPreset, detection, contexts, ciTarget, packageManager, setupOverwrite, securitySensitive);
   result.steps.push(setupResult.step);
   warnings += setupResult.step.warnings.length;
 
@@ -472,7 +473,8 @@ function runSetupPhase(
   contexts: ReturnType<typeof loadPackageContexts>,
   ciTarget: string | undefined,
   packageManager: 'npm' | 'pnpm',
-  force: boolean
+  force: boolean,
+  securitySensitive: boolean
 ): { step: StepResult } {
   const warnings: string[] = [];
   const created: string[] = [];
@@ -489,6 +491,7 @@ function runSetupPhase(
         react: detection.signals.hasReact,
         vite: detection.signals.hasVite,
       },
+      securitySensitive,
     });
 
     if (initResult.created) {

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -65,6 +65,18 @@ export async function doctorCommand(options: CLIOptions, args: string[] = []): P
       status: policyCount > 0 ? 'PASS' : 'WARN',
       details: policyCount > 0 ? `${policyCount} markdown policy file(s).` : 'No policy markdown files found.',
     });
+
+    const securityDenyPath = path.join(options.configPath, 'patterns', 'security-deny.json');
+    if (fs.existsSync(securityDenyPath)) {
+      const securityTestFiles = findSecurityTestFiles('.');
+      checks.push({
+        name: 'security test coverage',
+        status: securityTestFiles.length > 0 ? 'PASS' : 'WARN',
+        details: securityTestFiles.length > 0
+          ? `${securityTestFiles.length} security test file(s): ${securityTestFiles.slice(0, 5).join(', ')}`
+          : 'Security-sensitive repo has no **/security* or **/l4* test file. Add L4/security regression tests.',
+      });
+    }
   }
 
   // ADF readiness checks
@@ -341,6 +353,45 @@ export async function doctorCommand(options: CLIOptions, args: string[] = []): P
   }
 
   return EXIT_CODE.SUCCESS;
+}
+
+function findSecurityTestFiles(rootPath: string): string[] {
+  const matches: string[] = [];
+  const skipDirs = new Set(['.git', 'node_modules', 'dist', 'coverage', '.ai', '.charter']);
+
+  function walk(dir: string): void {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      const relPath = path.relative(rootPath, fullPath) || entry.name;
+      if (entry.isDirectory()) {
+        if (!skipDirs.has(entry.name)) {
+          walk(fullPath);
+        }
+        continue;
+      }
+
+      if (entry.isFile() && /^(security|l4)/i.test(entry.name) && isTestLikePath(relPath)) {
+        matches.push(relPath);
+      }
+    }
+  }
+
+  walk(rootPath);
+  return matches.sort();
+}
+
+function isTestLikePath(filePath: string): boolean {
+  const normalized = filePath.replace(/\\/g, '/').toLowerCase();
+  return normalized.includes('/test/')
+    || normalized.includes('/tests/')
+    || /\.(test|spec)\.[cm]?[jt]sx?$/.test(normalized);
 }
 
 

--- a/packages/cli/src/commands/drift.ts
+++ b/packages/cli/src/commands/drift.ts
@@ -12,7 +12,7 @@ import { EXIT_CODE } from '../index';
 import { getFlag } from '../flags';
 import { loadConfig, loadPatterns, getPatternCustomizationStatus } from '../config';
 import { scanForDrift } from '@stackbilt/drift';
-import type { DriftReport } from '@stackbilt/types';
+import type { DriftReport, DriftViolation, Pattern } from '@stackbilt/types';
 
 export async function driftCommand(options: CLIOptions, args: string[]): Promise<number> {
   const config = loadConfig(options.configPath);
@@ -67,11 +67,19 @@ export async function driftCommand(options: CLIOptions, args: string[]): Promise
     return options.ciMode ? EXIT_CODE.POLICY_VIOLATION : EXIT_CODE.SUCCESS;
   }
 
-  const report = scanForDrift(files, patterns);
-  const status: 'PASS' | 'FAIL' = report.score >= config.drift.minScore ? 'PASS' : 'FAIL';
+  const securityPatterns = loadSecurityDenyPatterns(options.configPath);
+  const securityReport = securityPatterns.length > 0 ? scanForDrift(files, securityPatterns) : null;
+  const securityViolations = (securityReport?.violations || []).map((violation) => ({
+    ...violation,
+    severity: 'BLOCKER' as const,
+  }));
+  const report = mergeReports(scanForDrift(files, patterns), securityViolations, securityPatterns.length);
+  const hasSecurityBlocker = securityViolations.length > 0;
+  const status: 'PASS' | 'FAIL' = report.score >= config.drift.minScore && !hasSecurityBlocker ? 'PASS' : 'FAIL';
   const patternsCustomized = getPatternCustomizationStatus(options.configPath);
   const output = {
     status,
+    securityBlockers: securityViolations.length,
     minScore: config.drift.minScore,
     thresholdPercent: Math.round(config.drift.minScore * 100),
     configPath: options.configPath,
@@ -82,24 +90,27 @@ export async function driftCommand(options: CLIOptions, args: string[]): Promise
   if (options.format === 'json') {
     console.log(JSON.stringify(output, null, 2));
   } else {
-    printReport(report, config.drift.minScore, patternsCustomized);
+    printReport(report, config.drift.minScore, patternsCustomized, securityViolations.length);
   }
 
-  if (options.ciMode && report.score < config.drift.minScore) {
+  if (options.ciMode && (report.score < config.drift.minScore || hasSecurityBlocker)) {
     return EXIT_CODE.POLICY_VIOLATION;
   }
 
   return EXIT_CODE.SUCCESS;
 }
 
-function printReport(report: DriftReport, minScore: number, patternsCustomized: boolean | null): void {
-  const icon = report.score >= minScore ? '[ok]' : '[fail]';
+function printReport(report: DriftReport, minScore: number, patternsCustomized: boolean | null, securityBlockers: number): void {
+  const icon = report.score >= minScore && securityBlockers === 0 ? '[ok]' : '[fail]';
   const pct = Math.round(report.score * 100);
 
   console.log(`\n  ${icon} Drift Score: ${pct}% (threshold: ${Math.round(minScore * 100)}%)`);
   console.log(`     Scanned: ${report.scannedFiles} files against ${report.scannedPatterns} patterns`);
   if (patternsCustomized !== null) {
     console.log(`     Patterns customized: ${patternsCustomized ? 'yes' : 'no'}`);
+  }
+  if (securityBlockers > 0) {
+    console.log(`     Security blockers: ${securityBlockers}`);
   }
 
   if (report.violations.length > 0) {
@@ -126,6 +137,53 @@ function printReport(report: DriftReport, minScore: number, patternsCustomized: 
   }
 
   console.log('');
+}
+
+function loadSecurityDenyPatterns(configPath: string): Pattern[] {
+  const denyPath = path.join(configPath, 'patterns', 'security-deny.json');
+  if (!fs.existsSync(denyPath)) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(fs.readFileSync(denyPath, 'utf-8'));
+    const rawPatterns = Array.isArray(parsed)
+      ? parsed
+      : Array.isArray(parsed?.patterns)
+        ? parsed.patterns
+        : [];
+
+    return rawPatterns.map((item: Record<string, unknown>, index: number) => ({
+      id: String(item.id || `security-deny-${index}`),
+      name: String(item.name || `Security Deny ${index + 1}`),
+      category: String(item.category || 'SECURITY'),
+      blessedSolution: String(item.blessed_solution || item.blessedSolution || ''),
+      rationale: typeof item.rationale === 'string' ? item.rationale : null,
+      antiPatterns: typeof item.anti_patterns === 'string'
+        ? item.anti_patterns
+        : typeof item.antiPatterns === 'string'
+          ? item.antiPatterns
+          : null,
+      documentationUrl: null,
+      relatedLedgerId: null,
+      status: 'ACTIVE' as const,
+      createdAt: new Date().toISOString(),
+      projectId: null,
+    }));
+  } catch {
+    console.warn(`Warning: Failed to parse security deny pattern file: ${denyPath}`);
+    return [];
+  }
+}
+
+function mergeReports(base: DriftReport, securityViolations: DriftViolation[], extraPatternCount: number): DriftReport {
+  const violations = [...base.violations, ...securityViolations];
+  return {
+    ...base,
+    violations,
+    scannedPatterns: base.scannedPatterns + extraPatternCount,
+    score: Math.max(0, 1.0 - (violations.length * 0.1)),
+  };
 }
 
 function collectFiles(

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -228,6 +228,73 @@ const GITIGNORE_CONTENT = `# Charter local state
 .cache/
 `;
 
+const SECURITY_TEMPLATE = `# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+| ------- | --------- |
+| Current release | Yes |
+
+## Reporting a Vulnerability
+
+Please report suspected vulnerabilities privately to the project maintainers.
+Do not open a public issue for security-sensitive findings.
+
+Include:
+- affected package or service
+- reproduction steps or proof of concept
+- expected impact
+- any known mitigations
+
+Maintainers should acknowledge reports within 3 business days and provide a remediation plan or status update when triage is complete.
+`;
+
+const SECURITY_DENY_PATTERNS = {
+  customized: false,
+  preset: 'security-sensitive',
+  generatedAt: '1970-01-01T00:00:00.000Z',
+  hardFail: true,
+  patterns: [
+    {
+      id: 'security-deny-timing-compare',
+      name: 'Security Deny: Timing-Sensitive Equality',
+      category: 'SECURITY',
+      blessed_solution: 'Use constant-time comparison helpers for signatures, digests, and tokens.',
+      rationale: 'Plain equality on security digests can leak timing information.',
+      anti_patterns: 'Avoid `/===\\s*(signature|expected|digest|token)/i` and `/(signature|expected|digest|token)\\s*===/i`.',
+      status: 'ACTIVE',
+    },
+    {
+      id: 'security-deny-optional-security-binding',
+      name: 'Security Deny: Optional Security Binding Access',
+      category: 'SECURITY',
+      blessed_solution: 'Fail closed when security-critical bindings are missing.',
+      rationale: 'Optional reads on auth/session/token bindings can silently bypass enforcement.',
+      anti_patterns: 'Avoid `/\\b(auth|session|token|secret|key)\\w*\\?\\.(get|put)\\s*\\(/i`.',
+      status: 'ACTIVE',
+    },
+    {
+      id: 'security-deny-auth-todo',
+      name: 'Security Deny: TODO in Security Path',
+      category: 'SECURITY',
+      blessed_solution: 'Resolve security TODOs before shipping auth, session, or token paths.',
+      rationale: 'TODO markers in security-sensitive code tend to become persistent control gaps.',
+      anti_patterns: 'Avoid `/TODO.*\\b(auth|session|token|secret|hmac|signature)\\b/i` and `/\\b(auth|session|token|secret|hmac|signature)\\b.*TODO/i`.',
+      status: 'ACTIVE',
+    },
+    {
+      id: 'security-deny-token-json-exposure',
+      name: 'Security Deny: Token JSON Exposure',
+      category: 'SECURITY',
+      blessed_solution: 'Return opaque success responses or scoped public metadata instead of raw access tokens.',
+      rationale: 'Raw token exposure in JSON responses increases credential leakage risk.',
+      anti_patterns: 'Avoid `/c\\.json\\s*\\(\\s*\\{\\s*access_token/i`.',
+      status: 'ACTIVE',
+    },
+  ],
+};
+
 interface InitResult {
   created: boolean;
   configPath: string;
@@ -244,6 +311,7 @@ interface InitializeOptions {
     react?: boolean;
     vite?: boolean;
   };
+  securitySensitive?: boolean;
 }
 
 export async function initCommand(options: CLIOptions, args: string[] = []): Promise<number> {
@@ -251,13 +319,14 @@ export async function initCommand(options: CLIOptions, args: string[] = []): Pro
   const guided = args.includes('--guided');
   const presetFlag = getFlag(args, '--preset');
   const preset = isValidPreset(presetFlag) ? presetFlag : undefined;
+  const securitySensitive = args.includes('--security-sensitive');
 
   // --guided: interactive mode that asks questions before scaffolding
   if (guided) {
     return guidedInit(options, force);
   }
 
-  const result = initializeCharter(options.configPath, force, { preset });
+  const result = initializeCharter(options.configPath, force, { preset, securitySensitive });
 
   if (options.format === 'json') {
     console.log(JSON.stringify(result, null, 2));
@@ -319,6 +388,10 @@ export function initializeCharter(configDir: string, force: boolean, initOptions
   if (writeIfChanged(path.join(configDir, 'patterns', 'blessed-stack.json'), JSON.stringify(patterns, null, 2) + '\n')) writesPerformed++;
   if (writeIfChanged(path.join(configDir, 'policies', 'governance.md'), DEFAULT_POLICY_CONTENT)) writesPerformed++;
   if (writeIfChanged(path.join(configDir, '.gitignore'), GITIGNORE_CONTENT)) writesPerformed++;
+  if (initOptions.securitySensitive) {
+    if (writeIfChanged(path.join(configDir, 'patterns', 'security-deny.json'), JSON.stringify(SECURITY_DENY_PATTERNS, null, 2) + '\n')) writesPerformed++;
+    if (writeIfChanged('SECURITY.md', SECURITY_TEMPLATE)) writesPerformed++;
+  }
 
   return {
     created: !exists,
@@ -328,6 +401,7 @@ export function initializeCharter(configDir: string, force: boolean, initOptions
       'patterns/blessed-stack.json',
       'policies/governance.md',
       '.gitignore',
+      ...(initOptions.securitySensitive ? ['patterns/security-deny.json', '../SECURITY.md'] : []),
     ],
     writesPerformed,
   };

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -194,7 +194,7 @@ export function loadPatterns(configPath: string): Pattern[] {
   }
 
   const patterns: Pattern[] = [];
-  const files = fs.readdirSync(patternsDir).filter(f => f.endsWith('.json'));
+  const files = fs.readdirSync(patternsDir).filter(f => f.endsWith('.json') && f !== 'security-deny.json');
 
   for (const file of files) {
     try {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -38,6 +38,7 @@ Usage:
   charter                          Show immediate governance value + risk snapshot
   charter bootstrap [--ci github] [--preset <name>] [--yes] [--force] [--skip-install] [--skip-doctor]
                                    One-command repo onboarding (detect + setup + ADF + install + doctor)
+                                   --security-sensitive adds SECURITY.md, hard security drift denies, and a security test check
   charter setup [--ci github] [--preset <worker|frontend|backend|fullstack>] [--detect-only] [--no-dependency-sync]
                                    Bootstrap .charter/ and optional CI workflow
   charter init [--preset <worker|frontend|backend|fullstack>] [--guided]


### PR DESCRIPTION
## Summary

Adds the security-sensitive bootstrap path requested in #100.

## Changes

- Adds `charter bootstrap --security-sensitive` support, wired through the existing setup phase.
- Generates a repo-root `SECURITY.md` responsible disclosure template.
- Seeds `.charter/patterns/security-deny.json` with hard-fail deny patterns for timing-sensitive comparisons, optional security binding access, security TODOs, and token JSON exposure.
- Makes `charter drift` load `security-deny.json` separately and report matches as `BLOCKER` violations that fail CI regardless of drift score.
- Adds a `charter doctor` warning for opted-in repos that do not have a `security*` or `l4*` test file.
- Documents the flag in README and CLI reference.

## Verification

- `pnpm exec vitest run packages/cli/src/__tests__/bootstrap.test.ts`
- `pnpm run typecheck`
- `pnpm exec vitest run packages/cli/src/__tests__` with elevated permissions for git-based fixture tests: 17 files / 91 tests passed

Addresses #100