### PR TITLE
feat(setup): detect npm/yarn workspace monorepos + brief stack fallback

### DIFF
--- a/packages/cli/src/__tests__/setup.test.ts
+++ b/packages/cli/src/__tests__/setup.test.ts
@@ -2,7 +2,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { getGithubWorkflow, syncPackageManifest } from '../commands/setup';
+import { detectStack, getGithubWorkflow, loadPackageContexts, syncPackageManifest } from '../commands/setup';
 
 const originalCwd = process.cwd();
 const tempDirs: string[] = [];
@@ -15,6 +15,84 @@ afterEach(() => {
       fs.rmSync(dir, { recursive: true, force: true });
     }
   }
+});
+
+describe('loadPackageContexts + detectStack (npm workspaces)', () => {
+  it('discovers packages listed via npm workspaces array glob', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'charter-setup-ws-'));
+    tempDirs.push(tmp);
+    process.chdir(tmp);
+
+    fs.writeFileSync(
+      'package.json',
+      JSON.stringify({ name: 'my-monorepo', version: '0.1.0', private: true, workspaces: ['packages/*'] }, null, 2),
+    );
+    fs.mkdirSync(path.join(tmp, 'packages', 'alpha'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, 'packages', 'alpha', 'package.json'),
+      JSON.stringify({ name: '@mono/alpha', version: '1.0.0', dependencies: { hono: '^4.0.0' } }, null, 2),
+    );
+    fs.mkdirSync(path.join(tmp, 'packages', 'beta'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, 'packages', 'beta', 'package.json'),
+      JSON.stringify({ name: '@mono/beta', version: '1.0.0' }, null, 2),
+    );
+
+    const contexts = loadPackageContexts();
+    const sources = contexts.map((c) => c.source);
+    expect(sources).toContain('packages/alpha/package.json');
+    expect(sources).toContain('packages/beta/package.json');
+  });
+
+  it('discovers packages via npm workspaces object form { packages: [...] }', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'charter-setup-ws-obj-'));
+    tempDirs.push(tmp);
+    process.chdir(tmp);
+
+    fs.writeFileSync(
+      'package.json',
+      JSON.stringify({
+        name: 'obj-monorepo',
+        version: '0.1.0',
+        private: true,
+        workspaces: { packages: ['apps/*'], nohoist: ['**/react'] },
+      }, null, 2),
+    );
+    fs.mkdirSync(path.join(tmp, 'apps', 'web'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, 'apps', 'web', 'package.json'),
+      JSON.stringify({ name: 'web', version: '0.0.1', dependencies: { react: '^18.0.0' } }, null, 2),
+    );
+
+    const contexts = loadPackageContexts();
+    const sources = contexts.map((c) => c.source);
+    expect(sources).toContain('apps/web/package.json');
+  });
+
+  it('sets monorepo=true and detects correct preset for npm workspace repo', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'charter-setup-ws-detect-'));
+    tempDirs.push(tmp);
+    process.chdir(tmp);
+
+    fs.writeFileSync(
+      'package.json',
+      JSON.stringify({ name: 'hono-mono', version: '0.1.0', private: true, workspaces: ['packages/*'] }, null, 2),
+    );
+    fs.mkdirSync(path.join(tmp, 'packages', 'api'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, 'packages', 'api', 'package.json'),
+      JSON.stringify({
+        name: '@mono/api',
+        version: '1.0.0',
+        dependencies: { hono: '^4.0.0', wrangler: '^3.0.0' },
+      }, null, 2),
+    );
+
+    const contexts = loadPackageContexts();
+    const result = detectStack(contexts);
+    expect(result.monorepo).toBe(true);
+    expect(result.suggestedPreset).toBe('worker');
+  });
 });
 
 describe('syncPackageManifest', () => {

--- a/packages/cli/src/commands/context.ts
+++ b/packages/cli/src/commands/context.ts
@@ -18,6 +18,7 @@ import { analyze as analyzeBlast, BlastInputSchema } from '@stackbilt/blast';
 import { analyze as analyzeSurface, SurfaceInputSchema } from '@stackbilt/surface';
 import { parseAdf, parseManifest } from '@stackbilt/adf';
 import { detectTsconfigAliases } from './blast';
+import { detectStack, loadPackageContexts } from './setup';
 import type { CLIOptions } from '../index';
 import { EXIT_CODE } from '../index';
 
@@ -591,6 +592,15 @@ export async function generateBrief(options?: BriefOptions): Promise<BriefResult
   }
   if ((stack === 'unknown' || stack.length === 0) && preset !== 'default') {
     stack = preset;
+  }
+  if (stack === 'unknown' || stack.length === 0) {
+    try {
+      const detection = detectStack(loadPackageContexts());
+      if (preset === 'default') preset = detection.suggestedPreset;
+      stack = detection.suggestedPreset;
+    } catch {
+      // detection unavailable — stack stays 'unknown'
+    }
   }
   const sensitivityTags = [...sensitivityTagSet];
 

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -455,7 +455,9 @@ export function detectStack(contexts: PackageContext[]): DetectionResult {
   const hasPnpm = contexts.some((ctx) => !!ctx.engines?.pnpm)
     || contexts.some((ctx) => typeof ctx.packageManager === 'string' && ctx.packageManager.toLowerCase().startsWith('pnpm@'))
     || fs.existsSync(path.resolve('pnpm-lock.yaml'));
-  const monorepo = contexts.length > 1 || fs.existsSync(path.resolve('pnpm-workspace.yaml'));
+  const monorepo = contexts.length > 1
+    || fs.existsSync(path.resolve('pnpm-workspace.yaml'))
+    || hasWorkspacesField();
   const agentStandards = ['AGENTS.md', 'CLAUDE.md', 'GEMINI.md']
     .filter((filename) => fs.existsSync(path.resolve(filename)));
 
@@ -669,6 +671,9 @@ export function loadPackageContexts(): PackageContext[] {
   for (const workspaceManifest of resolvePnpmWorkspacePackageJsons()) {
     candidates.add(workspaceManifest);
   }
+  for (const workspaceManifest of resolveNpmWorkspacePackageJsons()) {
+    candidates.add(workspaceManifest);
+  }
 
   const contexts: PackageContext[] = [];
   for (const relativePath of candidates) {
@@ -722,6 +727,45 @@ function resolvePnpmWorkspacePackageJsons(): string[] {
     }
   }
   return [...resolved];
+}
+
+function resolveNpmWorkspacePackageJsons(): string[] {
+  const rootPkgPath = path.resolve('package.json');
+  if (!fs.existsSync(rootPkgPath)) return [];
+  let pkg: { workspaces?: unknown };
+  try {
+    pkg = JSON.parse(fs.readFileSync(rootPkgPath, 'utf-8')) as { workspaces?: unknown };
+  } catch {
+    return [];
+  }
+  const raw = pkg.workspaces;
+  const globs: string[] = Array.isArray(raw)
+    ? (raw as unknown[]).filter((g): g is string => typeof g === 'string')
+    : Array.isArray((raw as { packages?: unknown })?.packages)
+      ? ((raw as { packages: unknown[] }).packages).filter((g): g is string => typeof g === 'string')
+      : [];
+  const resolved = new Set<string>();
+  for (const glob of globs) {
+    for (const match of expandWorkspacePackageJsonGlob(glob)) {
+      resolved.add(match);
+    }
+  }
+  return [...resolved];
+}
+
+function hasWorkspacesField(): boolean {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.resolve('package.json'), 'utf-8')) as { workspaces?: unknown };
+    const ws = pkg.workspaces;
+    if (Array.isArray(ws)) return ws.length > 0;
+    if (ws && typeof ws === 'object') {
+      const pkgs = (ws as { packages?: unknown[] }).packages;
+      return Array.isArray(pkgs) && pkgs.length > 0;
+    }
+    return false;
+  } catch {
+    return false;
+  }
 }
 
 function parsePnpmWorkspaceGlobs(content: string): string[] {


### PR DESCRIPTION
## Summary

- `loadPackageContexts()` now reads npm/yarn `workspaces` (array and `{ packages: [...] }` object forms) from the root `package.json` and expands each glob using the existing `expandWorkspacePackageJsonGlob` helper — workspace packages are included in detection alongside pnpm workspaces
- `detectStack()` `monorepo` flag now also fires when the root `package.json` carries a `workspaces` field (catches workspace roots even before sub-packages are loaded)
- `generateBrief()` (context.ts) calls `detectStack(loadPackageContexts())` as a final fallback when `stack` remains `'unknown'` after config + ADF resolution, so npm/yarn monorepos surface the correct preset automatically

Closes #160.

## Test plan

- [ ] `loadPackageContexts + detectStack (npm workspaces) > discovers packages listed via npm workspaces array glob`
- [ ] `loadPackageContexts + detectStack (npm workspaces) > discovers packages via npm workspaces object form { packages: [...] }`
- [ ] `loadPackageContexts + detectStack (npm workspaces) > sets monorepo=true and detects correct preset for npm workspace repo`
- [ ] Full suite: 496 tests pass (`pnpm vitest run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)