### PR TITLE
chore: add keywords, author, and provenance to all 12 packages

### DIFF
--- a/packages/adf/package.json
+++ b/packages/adf/package.json
@@ -29,7 +29,19 @@
   },
   "homepage": "https://github.com/Stackbilt-dev/charter#readme",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
+  "keywords": [
+    "charter",
+    "adf",
+    "governance",
+    "ai",
+    "agent",
+    "context",
+    "format",
+    "llm"
+  ],
+  "author": "Stackbilt LLC",
   "license": "Apache-2.0"
 }

--- a/packages/blast/package.json
+++ b/packages/blast/package.json
@@ -32,7 +32,18 @@
     "zod": "^3.24.1"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
+  "keywords": [
+    "charter",
+    "blast-radius",
+    "dependency-graph",
+    "static-analysis",
+    "governance",
+    "ai",
+    "llm"
+  ],
+  "author": "Stackbilt LLC",
   "license": "Apache-2.0"
 }

--- a/packages/ci/package.json
+++ b/packages/ci/package.json
@@ -35,7 +35,18 @@
     "prepublishOnly": "node ../../scripts/ensure-pnpm-publish.mjs"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
+  "keywords": [
+    "charter",
+    "ci",
+    "github-actions",
+    "governance",
+    "continuous-integration",
+    "ai",
+    "llm"
+  ],
+  "author": "Stackbilt LLC",
   "license": "Apache-2.0"
 }

--- a/packages/classify/package.json
+++ b/packages/classify/package.json
@@ -35,7 +35,18 @@
     "prepublishOnly": "node ../../scripts/ensure-pnpm-publish.mjs"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
+  "keywords": [
+    "charter",
+    "classify",
+    "change-detection",
+    "heuristic",
+    "governance",
+    "ai",
+    "llm"
+  ],
+  "author": "Stackbilt LLC",
   "license": "Apache-2.0"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -33,8 +33,21 @@
   },
   "homepage": "https://github.com/Stackbilt-dev/charter#readme",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
+  "keywords": [
+    "charter",
+    "cli",
+    "governance",
+    "scaffold",
+    "monorepo",
+    "typescript",
+    "architecture",
+    "ai",
+    "agent",
+    "llm"
+  ],
   "scripts": {
     "prepublishOnly": "node ../../scripts/ensure-pnpm-publish.mjs",
     "build": "pnpm exec tsc -p tsconfig.json"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,7 +32,18 @@
     "zod": "^3.24.1"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
+  "keywords": [
+    "charter",
+    "core",
+    "schema",
+    "validation",
+    "governance",
+    "ai",
+    "llm"
+  ],
+  "author": "Stackbilt LLC",
   "license": "Apache-2.0"
 }

--- a/packages/drift/package.json
+++ b/packages/drift/package.json
@@ -35,7 +35,18 @@
     "prepublishOnly": "node ../../scripts/ensure-pnpm-publish.mjs"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
+  "keywords": [
+    "charter",
+    "drift",
+    "scanner",
+    "divergence",
+    "governance",
+    "ai",
+    "llm"
+  ],
+  "author": "Stackbilt LLC",
   "license": "Apache-2.0"
 }

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -35,7 +35,19 @@
     "prepublishOnly": "node ../../scripts/ensure-pnpm-publish.mjs"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
+  "keywords": [
+    "charter",
+    "git",
+    "commit",
+    "trailer",
+    "risk-scoring",
+    "governance",
+    "ai",
+    "llm"
+  ],
+  "author": "Stackbilt LLC",
   "license": "Apache-2.0"
 }

--- a/packages/policies/package.json
+++ b/packages/policies/package.json
@@ -33,7 +33,19 @@
     "prepublishOnly": "node ../../scripts/ensure-pnpm-publish.mjs"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
+  "keywords": [
+    "charter",
+    "policy",
+    "supply-chain",
+    "security",
+    "governance",
+    "ci",
+    "ai",
+    "llm"
+  ],
+  "author": "Stackbilt LLC",
   "license": "Apache-2.0"
 }

--- a/packages/surface/package.json
+++ b/packages/surface/package.json
@@ -32,7 +32,21 @@
     "zod": "^3.24.1"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
+  "keywords": [
+    "charter",
+    "surface",
+    "api",
+    "routes",
+    "schema",
+    "hono",
+    "express",
+    "governance",
+    "ai",
+    "llm"
+  ],
+  "author": "Stackbilt LLC",
   "license": "Apache-2.0"
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -29,7 +29,17 @@
   },
   "homepage": "https://github.com/Stackbilt-dev/charter#readme",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
+  "keywords": [
+    "charter",
+    "types",
+    "typescript",
+    "governance",
+    "ai",
+    "llm"
+  ],
+  "author": "Stackbilt LLC",
   "license": "Apache-2.0"
 }

--- a/packages/validate/package.json
+++ b/packages/validate/package.json
@@ -35,7 +35,17 @@
     "prepublishOnly": "node ../../scripts/ensure-pnpm-publish.mjs"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
+  "keywords": [
+    "charter",
+    "validate",
+    "citation",
+    "governance",
+    "ai",
+    "llm"
+  ],
+  "author": "Stackbilt LLC",
   "license": "Apache-2.0"
 }


### PR DESCRIPTION
## Summary

- Added `keywords` array (6-10 terms: charter, domain, ai/llm/governance) to all 12 `@stackbilt/*` packages — zero-friction discoverability on npmjs.com
- Added `author: "Stackbilt LLC"` to the 11 packages that were missing it (cli already had it)
- Added `publishConfig.provenance: true` to all 12 packages — enables npm provenance attestation on every release via Sigstore, letting consumers verify build provenance

Closes #165.

## Test plan

- [ ] All 490 tests pass (`pnpm vitest run`)
- [ ] `pnpm --filter @stackbilt/adf exec cat package.json | jq '.keywords,.author,.publishConfig'` returns populated fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)