### PR TITLE
chore(oss): ship CodeQL, CoC, CODEOWNERS coverage, and policy-block fallback

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,11 @@
 # Catch-all: require review across the repo
-* @Stackbilt-dev/charter-maintainers
+* @stackbilt-admin
 
 # Governance context files
 /.ai/* admin@stackbilt.dev
 
 # CLI command surface
-/packages/cli/src/commands/ @Stackbilt-dev/charter-maintainers
+/packages/cli/src/commands/ @stackbilt-admin
 
 # High-risk release pipeline
-/.github/workflows/release.yml @Stackbilt-dev/charter-maintainers
+/.github/workflows/release.yml @stackbilt-admin

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,11 @@
-# Require explicit review for governance context changes
+# Catch-all: require review across the repo
+* @Stackbilt-dev/charter-maintainers
+
+# Governance context files
 /.ai/* admin@stackbilt.dev
+
+# CLI command surface
+/packages/cli/src/commands/ @Stackbilt-dev/charter-maintainers
+
+# High-risk release pipeline
+/.github/workflows/release.yml @Stackbilt-dev/charter-maintainers

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,39 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: '20 5 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - javascript-typescript
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for
+moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+admin@stackbilt.dev.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,6 +100,21 @@ To add personal overrides, create `.claude/settings.local.json`:
 }
 ```
 
+### Policy-Block Fallback For OSS Governance Files
+
+If an assistant run is blocked by model policy while editing standard OSS
+governance/security-posture files (for example `CODE_OF_CONDUCT.md`,
+`.github/CODEOWNERS`, `.github/workflows/codeql.yml`, `SECURITY.md`):
+
+1. Continue delivery on a normal git branch using manual edits or an alternate tool.
+2. Record reproducible evidence in a GitHub issue:
+   - exact request text
+   - exact error text
+   - UTC timestamp
+   - repo + branch context
+3. Link the upstream provider escalation issue from the local issue.
+4. Do not leave the repository blocked while waiting for a provider-side policy fix.
+
 ## Reporting Issues
 
 Use GitHub Issues for bugs/features. Include Node.js version, OS, and `charter --version` output.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,12 +31,15 @@ This policy covers Charter Kit OSS packages:
 - `@stackbilt/types`
 - `@stackbilt/core`
 - `@stackbilt/adf`
+- `@stackbilt/blast`
 - `@stackbilt/git`
 - `@stackbilt/classify`
 - `@stackbilt/validate`
 - `@stackbilt/drift`
 - `@stackbilt/cli`
 - `@stackbilt/ci`
+- `@stackbilt/policies`
+- `@stackbilt/surface`
 
 
 ## Security Design


### PR DESCRIPTION
## Summary

Implements the OSS hygiene/security posture changes tracked in #166 and adds a documented fallback path for assistant policy blocks tracked in #172.

### Shipped

- Added root `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1, enforcement contact `admin@stackbilt.dev`)
- Added `.github/workflows/codeql.yml` for JS/TS code scanning on push/PR to `main` + weekly schedule
- Expanded `.github/CODEOWNERS` to include catch-all ownership + critical path overrides
- Updated `SECURITY.md` scope to include all 12 OSS packages
- Added `CONTRIBUTING.md` mitigation guidance for policy-blocked governance/security file edits

## Why

- Close repo-level OSS trust gaps called out in #166
- Prevent delivery stalls when model policy blocks defensive governance/security-posture file updates (#172)

## Validation

- Verified file presence and content in repo:
  - `CODE_OF_CONDUCT.md`
  - `.github/workflows/codeql.yml`
  - `.github/CODEOWNERS`
  - `SECURITY.md`
  - `CONTRIBUTING.md`

Closes #166
Refs #172
