### PR TITLE
chore: fix GitHub license detection (Apache-2.0 showed as NOASSERTION)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,18 +1,3 @@
-Copyright 2026 Stackbilt LLC
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
----
 
                                  Apache License
                            Version 2.0, January 2004
@@ -64,7 +49,7 @@ limitations under the License.
       "Contribution" shall mean any work of authorship, including
       the original version of the Work and any modifications or additions
       to that Work or Derivative Works thereof, that is intentionally
-      submitted to the Licensor for inclusion in the Work by the copyright owner
+      submitted to Licensor for inclusion in the Work by the copyright owner
       or by an individual or Legal Entity authorized to submit on behalf of
       the copyright owner. For the purposes of this definition, "submitted"
       means any form of electronic, verbal, or written communication sent
@@ -76,7 +61,7 @@ limitations under the License.
       designated in writing by the copyright owner as "Not a Contribution."
 
       "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by the Licensor and
+      on behalf of whom a Contribution has been received by Licensor and
       subsequently incorporated within the Work.
 
    2. Grant of Copyright License. Subject to the terms and conditions of
@@ -122,7 +107,7 @@ limitations under the License.
       (d) If the Work includes a "NOTICE" text file as part of its
           distribution, then any Derivative Works that You distribute must
           include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding any notices that do not
+          within such NOTICE file, excluding those notices that do not
           pertain to any part of the Derivative Works, in at least one
           of the following places: within a NOTICE text file distributed
           as part of the Derivative Works; within the Source form or
@@ -191,7 +176,18 @@ limitations under the License.
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2026 Stackbilt LLC
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,2 @@
+Charter
+Copyright 2026 Stackbilt LLC


### PR DESCRIPTION
GitHub's license detection (licensee) needs a near-verbatim LICENSE match. The prepended copyright header made the repo report `NOASSERTION` instead of Apache-2.0 — visible on the repo page and in the API. This swaps in the canonical Apache-2.0 text and moves the copyright line to a standard NOTICE file (as Apache-2.0 §4(d) prescribes). No license change, detection-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)