### PR TITLE
fix(compiler): emit cwd-relative paths in agents-modules index (spec §4.2)

### DIFF
--- a/packages/adf/src/__tests__/compiler.test.ts
+++ b/packages/adf/src/__tests__/compiler.test.ts
@@ -75,6 +75,7 @@ function makeOptions(target: CompileOptions['target'], extra?: Record<string, st
   return {
     target,
     aiDir: '/ai',
+    displayAiDir: '.ai',
     readFile: makeReadFile({ ...FILES, ...extra }),
   };
 }
@@ -275,10 +276,10 @@ describe('compileAdf — on-demand module index (spec §4.2)', () => {
     expect(result.output).not.toContain(`<!-- ${MODULE_INDEX_FENCE} -->`);
   });
 
-  it('lists each on-demand module with its aiDir-prefixed path and triggers', () => {
+  it('lists each on-demand module with its displayAiDir-relative path and triggers', () => {
     const result = compileAdf(makeOptions('claude'));
-    expect(result.output).toContain('`/ai/frontend.adf` — Triggers: React, CSS, UI');
-    expect(result.output).toContain('`/ai/backend.adf` — Triggers: API, Node, DB');
+    expect(result.output).toContain('`.ai/frontend.adf` — Triggers: React, CSS, UI');
+    expect(result.output).toContain('`.ai/backend.adf` — Triggers: API, Node, DB');
   });
 
   it('omits the index when no on-demand modules exist', () => {
@@ -308,9 +309,10 @@ describe('compileAdf — on-demand module index (spec §4.2)', () => {
     const result = compileAdf({
       target: 'claude',
       aiDir: '/ai',
+      displayAiDir: '.ai',
       readFile: makeReadFile({ ...FILES, '/ai/manifest.adf': manifestNoTriggers }),
     });
-    expect(result.output).toContain('`/ai/extras.adf`');
+    expect(result.output).toContain('`.ai/extras.adf`');
     // No trigger annotation for modules without triggers
     expect(result.output).not.toContain('extras.adf` — Triggers:');
   });

--- a/packages/adf/src/compiler.ts
+++ b/packages/adf/src/compiler.ts
@@ -27,6 +27,8 @@ export interface CompileOptions {
   target: CompileTarget;
   /** Base directory for resolving module paths (e.g. '.ai') */
   aiDir: string;
+  /** Display path used in the module index entries — should be cwd-relative (e.g. '.ai'). Defaults to the last segment of aiDir. */
+  displayAiDir?: string;
   /** File reader injection — allows DI for testing without disk access */
   readFile: (path: string) => string;
 }
@@ -123,6 +125,8 @@ export interface CompileResult {
  */
 export function compileAdf(options: CompileOptions): CompileResult {
   const { target, aiDir, readFile } = options;
+  // Use the caller-supplied display path, or fall back to the last path segment
+  const displayAiDir = options.displayAiDir ?? lastSegment(aiDir);
 
   // Load and parse manifest
   const manifestPath = joinPath(aiDir, 'manifest.adf');
@@ -140,7 +144,7 @@ export function compileAdf(options: CompileOptions): CompileResult {
   }
 
   const config = TARGET_CONFIGS[target];
-  const output = renderToVendorFormat(config, manifest, defaultSections, manifest.onDemand, aiDir);
+  const output = renderToVendorFormat(config, manifest, defaultSections, manifest.onDemand, displayAiDir);
 
   return {
     target,
@@ -159,7 +163,7 @@ function renderToVendorFormat(
   manifest: Manifest,
   defaultSections: AdfSection[],
   onDemandModules: ManifestModule[],
-  aiDir: string,
+  displayAiDir: string,
 ): string {
   const lines: string[] = [];
 
@@ -200,7 +204,7 @@ function renderToVendorFormat(
       const triggerStr = mod.triggers.length > 0
         ? ` — Triggers: ${mod.triggers.join(', ')}`
         : '';
-      lines.push(`- \`${joinPath(aiDir, mod.path)}\`${triggerStr}`);
+      lines.push(`- \`${joinPath(displayAiDir, mod.path)}\`${triggerStr}`);
     }
     lines.push(buildModuleIndexFence(config.commentStyle, 'close'));
     lines.push('');
@@ -295,4 +299,10 @@ function renderContent(content: AdfContent): string[] {
 function joinPath(base: string, relative: string): string {
   if (base.endsWith('/')) return base + relative;
   return base + '/' + relative;
+}
+
+function lastSegment(p: string): string {
+  const trimmed = p.replace(/\/$/, '');
+  const idx = trimmed.lastIndexOf('/');
+  return idx < 0 ? trimmed : trimmed.slice(idx + 1);
 }

--- a/packages/cli/src/commands/adf-compile.ts
+++ b/packages/cli/src/commands/adf-compile.ts
@@ -56,6 +56,7 @@ export function adfCompileCommand(options: CLIOptions, args: string[]): number {
   const targetOrAll: CompileTargetOrAll = targetParsed.data;
 
   const aiDir = getFlag(args, '--ai-dir') || '.ai';
+  const displayAiDir = path.relative(process.cwd(), path.resolve(aiDir)) || aiDir;
   const writeMode = args.includes('--write');
   const checkMode = args.includes('--check');
   const forceWrite = args.includes('--force');
@@ -80,11 +81,11 @@ export function adfCompileCommand(options: CLIOptions, args: string[]): number {
   const readFile = (p: string): string => fs.readFileSync(p, 'utf-8');
 
   if (checkMode) {
-    return runCheckMode(options, targets, aiDir, readFile);
+    return runCheckMode(options, targets, aiDir, displayAiDir, readFile);
   }
 
   if (writeMode) {
-    return runWriteMode(options, targets, aiDir, readFile, forceWrite);
+    return runWriteMode(options, targets, aiDir, displayAiDir, readFile, forceWrite);
   }
 
   // Default: stdout (single target only in non-write/check mode)
@@ -93,7 +94,7 @@ export function adfCompileCommand(options: CLIOptions, args: string[]): number {
       '--target all requires --write or --check. Use a single target to print to stdout.',
     );
   }
-  return runStdoutMode(options, targets[0], aiDir, readFile);
+  return runStdoutMode(options, targets[0], aiDir, displayAiDir, readFile);
 }
 
 // ============================================================================
@@ -104,9 +105,10 @@ function runStdoutMode(
   options: CLIOptions,
   target: CompileTarget,
   aiDir: string,
+  displayAiDir: string,
   readFile: (p: string) => string,
 ): number {
-  const result = compileAdf({ target, aiDir, readFile });
+  const result = compileAdf({ target, aiDir, displayAiDir, readFile });
 
   if (options.format === 'json') {
     console.log(JSON.stringify({
@@ -134,6 +136,7 @@ function runWriteMode(
   options: CLIOptions,
   targets: CompileTarget[],
   aiDir: string,
+  displayAiDir: string,
   readFile: (p: string) => string,
   force: boolean,
 ): number {
@@ -159,7 +162,7 @@ function runWriteMode(
       }
     }
 
-    const result = compileAdf({ target, aiDir, readFile });
+    const result = compileAdf({ target, aiDir, displayAiDir, readFile });
     fs.writeFileSync(filename, result.output, 'utf-8');
     written.push(filename);
 
@@ -194,6 +197,7 @@ function runCheckMode(
   options: CLIOptions,
   targets: CompileTarget[],
   aiDir: string,
+  displayAiDir: string,
   readFile: (p: string) => string,
 ): number {
   const stale: string[] = [];
@@ -212,7 +216,7 @@ function runCheckMode(
     }
 
     const onDisk = fs.readFileSync(filename, 'utf-8');
-    const result = compileAdf({ target, aiDir, readFile });
+    const result = compileAdf({ target, aiDir, displayAiDir, readFile });
 
     if (onDisk === result.output) {
       current.push(filename);


### PR DESCRIPTION
## Summary

- The module index fence (§4.2) was emitting absolute paths like `/Users/x/repo/.ai/frontend.adf` instead of cwd-relative `.ai/frontend.adf`
- Added `displayAiDir?: string` to `CompileOptions` — the CLI sets it via `path.relative(cwd, aiDir)`; the pure compiler core falls back to `lastSegment(aiDir)` if omitted (zero-dep constraint preserved)
- Updated compiler tests to pass `displayAiDir: '.ai'` and expect the spec-correct `.ai/` prefix

## Why it matters

This was found while writing the conformance fixtures for `adf-spec/adf` — the fixture `expected.AGENTS.md` must be byte-exact, and absolute paths would make it machine-specific. Spec §4.2 shows `.ai/frontend.adf` (relative); the compiler now matches.

## Test plan

- [x] 643/643 tests pass
- [x] `charter adf compile --target agents --ai-dir .ai` (run from repo root) produces `.ai/frontend.adf` in the index
- [x] Compiler remains a pure zero-dep function

🤖 Generated with [Claude Code](https://claude.com/claude-code)