### PR TITLE
chore(scaffold-core): add to release pipeline + bump version to 1.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,6 +178,7 @@ jobs:
           pack_package packages/policies
           pack_package packages/ci
           pack_package packages/cli
+          pack_package packages/scaffold-core
 
           # publish_if_missing: skip packages already published at this version (idempotent re-runs)
           publish_if_missing() {
@@ -201,4 +202,5 @@ jobs:
           publish_if_missing "./release-tarballs/stackbilt-surface-${VERSION}.tgz"  "@stackbilt/surface"
           publish_if_missing "./release-tarballs/stackbilt-policies-${VERSION}.tgz" "@stackbilt/policies"
           publish_if_missing "./release-tarballs/stackbilt-ci-${VERSION}.tgz"       "@stackbilt/ci"
-          publish_if_missing "./release-tarballs/stackbilt-cli-${VERSION}.tgz"      "@stackbilt/cli"
+          publish_if_missing "./release-tarballs/stackbilt-cli-${VERSION}.tgz"          "@stackbilt/cli"
+          publish_if_missing "./release-tarballs/stackbilt-scaffold-core-${VERSION}.tgz" "@stackbilt/scaffold-core"

--- a/packages/scaffold-core/package.json
+++ b/packages/scaffold-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stackbilt/scaffold-core",
   "sideEffects": false,
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Zero-dependency scaffold engine core — pattern classification, knowledge, governance, codegen, and materializer",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/scaffold-core/src/__tests__/package.test.ts
+++ b/packages/scaffold-core/src/__tests__/package.test.ts
@@ -12,8 +12,8 @@ describe('@stackbilt/scaffold-core package metadata', () => {
     expect(pkg.name).toBe('@stackbilt/scaffold-core');
   });
 
-  it('version is 0.1.0', () => {
-    expect(pkg.version).toBe('0.1.0');
+  it('version is 1.0.0', () => {
+    expect(pkg.version).toBe('1.0.0');
   });
 
   it('license is Apache-2.0', () => {

--- a/scripts/assert-packages-publishable.mjs
+++ b/scripts/assert-packages-publishable.mjs
@@ -18,6 +18,7 @@ const packageGlobs = [
   "packages/surface",
   "packages/ci",
   "packages/cli",
+  "packages/scaffold-core",
 ];
 const dependencyFields = [
   "dependencies",


### PR DESCRIPTION
## Summary

- Bump `@stackbilt/scaffold-core` version `0.1.0` → `1.0.0` to match workspace version
- Add `packages/scaffold-core` to `scripts/assert-packages-publishable.mjs` check list
- Add `scaffold-core` pack + publish steps to `release.yml` workflow

## After merge

Trigger `workflow_dispatch` on tag `v1.0.0` to publish `@stackbilt/scaffold-core@1.0.0` (and skip all already-published packages via the idempotent `publish_if_missing` guard).

This unblocks: stackbilt-build#4, stackbilt-web#181, stackbilt-mcp-gateway#50.