### PR TITLE
fix(scaffold-core): Stripe keyword no longer dominates SaaS intent

### DIFF
--- a/packages/scaffold-core/package.json
+++ b/packages/scaffold-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stackbilt/scaffold-core",
   "sideEffects": false,
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Zero-dependency scaffold engine core — pattern classification, knowledge, governance, codegen, and materializer",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/scaffold-core/src/__tests__/classify.test.ts
+++ b/packages/scaffold-core/src/__tests__/classify.test.ts
@@ -140,6 +140,40 @@ describe('classification quality and confidence', () => {
   });
 });
 
+// ─── Stripe keyword dominance regression (#424) ─────────────────────────────
+
+describe('scaffold_classify — Stripe keyword does not dominate SaaS intent (#424)', () => {
+  it('SaaS billing dashboard with Stripe integration classifies as workers-saas', () => {
+    const result = classify(
+      'Build me a SaaS billing dashboard with Stripe integration, user management, and usage analytics',
+    );
+    expect(result.pattern).toBe('workers-saas');
+    expect(result.traits).toContain('jwt-auth');
+    expect(result.traits).not.toContain('hmac-stripe');
+  });
+
+  it('explicit Stripe webhook still classifies as stripe-webhook pattern', () => {
+    const result = classify('Build a Stripe webhook handler with HMAC verification and event routing');
+    expect(result.traits).toContain('hmac-stripe');
+    expect(result.confidence).toBeGreaterThan(0.5);
+  });
+
+  it('billing alone without payment keywords does not fire Payment Signal', () => {
+    const result = classify('Build a billing management dashboard with invoices and PDF export');
+    expect(result.traits).not.toContain('hmac-stripe');
+  });
+
+  it('stripe + billing together still classifies as stripe-webhook', () => {
+    const result = classify('Stripe billing webhook for subscription lifecycle events');
+    expect(result.traits).toContain('hmac-stripe');
+  });
+
+  it('dashboard keyword contributes to SaaS Signal score', () => {
+    const result = classify('Admin dashboard with user management, roles, and audit logs');
+    expect(result.pattern).toBe('workers-saas');
+  });
+});
+
 // ─── Rust/WASM classification tests (charter#230) ────────────────────────────
 
 describe('Rust/WASM pattern classification', () => {

--- a/packages/scaffold-core/src/__tests__/package.test.ts
+++ b/packages/scaffold-core/src/__tests__/package.test.ts
@@ -12,8 +12,8 @@ describe('@stackbilt/scaffold-core package metadata', () => {
     expect(pkg.name).toBe('@stackbilt/scaffold-core');
   });
 
-  it('version is 1.7.0', () => {
-    expect(pkg.version).toBe('1.7.0');
+  it('version is 1.7.1', () => {
+    expect(pkg.version).toBe('1.7.1');
   });
 
   it('license is Apache-2.0', () => {

--- a/packages/scaffold-core/src/classify/patterns.ts
+++ b/packages/scaffold-core/src/classify/patterns.ts
@@ -78,9 +78,12 @@ export const SCORED_PATTERNS: ScoredPatternDef[] = [
     signal: 'Payment Signal',
     priority: 100,
     score: (text: string) => {
-      const stripeHits = keywordScore(text, ['stripe', 'billing', 'subscription', 'checkout', 'payment', 'payments']);
-      if (stripeHits === 0 && text.includes('webhook')) return 0;
-      return stripeHits + (text.includes('webhook') ? 1 : 0);
+      // "billing" is intentionally excluded here — it appears in architectural contexts
+      // ("billing dashboard", "billing management") that are not Stripe webhook handlers.
+      // Require at least one explicit payment-action keyword before scoring billing terms.
+      const stripeHits = keywordScore(text, ['stripe', 'subscription', 'checkout', 'payment', 'payments']);
+      if (stripeHits === 0) return 0;
+      return stripeHits + (text.includes('billing') ? 1 : 0) + (text.includes('webhook') ? 1 : 0);
     },
     traitMap: {
       route_shape: 'post-handler',
@@ -104,7 +107,9 @@ export const SCORED_PATTERNS: ScoredPatternDef[] = [
     signal: 'Webhook Signal',
     priority: 95,
     score: (text: string) => {
-      if (keywordScore(text, ['stripe', 'billing', 'subscription', 'checkout', 'payment', 'payments']) >= 1) return 0;
+      // Exclude only if explicit payment-action keywords are present (not "billing" alone —
+      // see Payment Signal comment; "billing webhook" without Stripe is generic).
+      if (keywordScore(text, ['stripe', 'subscription', 'checkout', 'payment', 'payments']) >= 1) return 0;
       return keywordScore(text, ['webhook', 'signature verification', 'x-hub-signature', 'github webhook', 'slack webhook', 'twilio webhook']);
     },
     traitMap: {
@@ -124,11 +129,14 @@ export const SCORED_PATTERNS: ScoredPatternDef[] = [
     name: 'workers-saas' as PatternName,
     status: 'ACTIVE',
     category: 'COMPUTE',
-    keywords: ['saas', 'tenant', 'multi-tenant', 'org', 'workspace'],
+    keywords: ['saas', 'tenant', 'multi-tenant', 'org', 'workspace', 'dashboard', 'analytics', 'user management'],
     traits: ['rest', 'jwt-auth', 'resource-router', 'fetch-trigger'],
     signal: 'SaaS Signal',
     priority: 90,
-    score: (text: string) => keywordScore(text, ['saas', 'tenant', 'multi-tenant', 'org', 'workspace']),
+    score: (text: string) => keywordScore(
+      text,
+      ['saas', 'tenant', 'multi-tenant', 'org', 'workspace', 'dashboard', 'analytics', 'user management'],
+    ),
     traitMap: {
       route_shape: 'rest',
       verification: 'jwt-auth',


### PR DESCRIPTION
## Problem

`scaffold_classify` was misclassifying SaaS architectural intents as Stripe webhook
handlers whenever the word `billing` appeared alongside `stripe`.

Reproduction:
> "Build me a SaaS billing dashboard with Stripe integration, user management, and usage analytics"

Expected: `workers-saas` · Got: stripe-webhook (Payment Signal score 2 vs SaaS 1)

Root cause: `billing` in the Payment Signal's scoring keyword list fired on "billing dashboard"
— an architectural term, not a Stripe webhook signal.

## Changes

**`patterns.ts`**
- Payment Signal `score()`: removes `billing` from the keyword list; `billing` now only
  contributes +1 when at least one other payment-action keyword is already present.
- Webhook Signal guard: removes `billing` from the payment-action exclusion list.
- SaaS Signal: adds `dashboard`, `analytics`, `user management` to score keywords.

**Tests**: 5 new regression cases. **Version**: 1.7.0 → 1.7.1. 775/775 tests passing.

## Downstream

After merging + publishing, run `pnpm update @stackbilt/scaffold-core` in the
`stackbilt-mcp-gateway` repo to pick up the fix.

Closes #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)