### PR TITLE
fix(scaffold-core): prevent Stripe keyword from dominating SaaS intent

### DIFF
--- a/packages/scaffold-core/package.json
+++ b/packages/scaffold-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stackbilt/scaffold-core",
   "sideEffects": false,
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Zero-dependency scaffold engine core — pattern classification, knowledge, governance, codegen, and materializer",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/scaffold-core/src/__tests__/classify.test.ts
+++ b/packages/scaffold-core/src/__tests__/classify.test.ts
@@ -140,6 +140,40 @@ describe('classification quality and confidence', () => {
   });
 });
 
+// ─── Stripe keyword dominance regression (#424) ─────────────────────────────
+
+describe('scaffold_classify — Stripe keyword does not dominate SaaS intent (#424)', () => {
+  it('SaaS billing dashboard with Stripe integration classifies as workers-saas', () => {
+    const result = classify(
+      'Build me a SaaS billing dashboard with Stripe integration, user management, and usage analytics',
+    );
+    expect(result.pattern).toBe('workers-saas');
+    expect(result.traits).toContain('jwt-auth');
+    expect(result.traits).not.toContain('hmac-stripe');
+  });
+
+  it('explicit Stripe webhook still classifies as stripe-webhook pattern', () => {
+    const result = classify('Build a Stripe webhook handler with HMAC verification and event routing');
+    expect(result.traits).toContain('hmac-stripe');
+    expect(result.confidence).toBeGreaterThan(0.5);
+  });
+
+  it('billing alone without payment keywords does not fire Payment Signal', () => {
+    const result = classify('Build a billing management dashboard with invoices and PDF export');
+    expect(result.traits).not.toContain('hmac-stripe');
+  });
+
+  it('stripe + billing together still classifies as stripe-webhook', () => {
+    const result = classify('Stripe billing webhook for subscription lifecycle events');
+    expect(result.traits).toContain('hmac-stripe');
+  });
+
+  it('dashboard keyword contributes to SaaS Signal score', () => {
+    const result = classify('Admin dashboard with user management, roles, and audit logs');
+    expect(result.pattern).toBe('workers-saas');
+  });
+});
+
 // ─── Rust/WASM classification tests (charter#230) ────────────────────────────
 
 describe('Rust/WASM pattern classification', () => {

--- a/packages/scaffold-core/src/__tests__/package.test.ts
+++ b/packages/scaffold-core/src/__tests__/package.test.ts
@@ -12,8 +12,8 @@ describe('@stackbilt/scaffold-core package metadata', () => {
     expect(pkg.name).toBe('@stackbilt/scaffold-core');
   });
 
-  it('version is 1.7.0', () => {
-    expect(pkg.version).toBe('1.7.0');
+  it('version is 1.7.1', () => {
+    expect(pkg.version).toBe('1.7.1');
   });
 
   it('license is Apache-2.0', () => {

--- a/packages/scaffold-core/src/classify/patterns.ts
+++ b/packages/scaffold-core/src/classify/patterns.ts
@@ -78,9 +78,12 @@ export const SCORED_PATTERNS: ScoredPatternDef[] = [
     signal: 'Payment Signal',
     priority: 100,
     score: (text: string) => {
-      const stripeHits = keywordScore(text, ['stripe', 'billing', 'subscription', 'checkout', 'payment', 'payments']);
-      if (stripeHits === 0 && text.includes('webhook')) return 0;
-      return stripeHits + (text.includes('webhook') ? 1 : 0);
+      // "billing" is intentionally excluded here — it appears in architectural contexts
+      // ("billing dashboard", "billing management") that are not Stripe webhook handlers.
+      // Require at least one explicit payment-action keyword before scoring billing terms.
+      const stripeHits = keywordScore(text, ['stripe', 'subscription', 'checkout', 'payment', 'payments']);
+      if (stripeHits === 0) return 0;
+      return stripeHits + (text.includes('billing') ? 1 : 0) + (text.includes('webhook') ? 1 : 0);
     },
     traitMap: {
       route_shape: 'post-handler',
@@ -104,7 +107,9 @@ export const SCORED_PATTERNS: ScoredPatternDef[] = [
     signal: 'Webhook Signal',
     priority: 95,
     score: (text: string) => {
-      if (keywordScore(text, ['stripe', 'billing', 'subscription', 'checkout', 'payment', 'payments']) >= 1) return 0;
+      // Exclude only if explicit payment-action keywords are present (not "billing" alone —
+      // see Payment Signal comment; "billing webhook" without Stripe is generic).
+      if (keywordScore(text, ['stripe', 'subscription', 'checkout', 'payment', 'payments']) >= 1) return 0;
       return keywordScore(text, ['webhook', 'signature verification', 'x-hub-signature', 'github webhook', 'slack webhook', 'twilio webhook']);
     },
     traitMap: {
@@ -124,11 +129,14 @@ export const SCORED_PATTERNS: ScoredPatternDef[] = [
     name: 'workers-saas' as PatternName,
     status: 'ACTIVE',
     category: 'COMPUTE',
-    keywords: ['saas', 'tenant', 'multi-tenant', 'org', 'workspace'],
+    keywords: ['saas', 'tenant', 'multi-tenant', 'org', 'workspace', 'dashboard', 'analytics', 'user management'],
     traits: ['rest', 'jwt-auth', 'resource-router', 'fetch-trigger'],
     signal: 'SaaS Signal',
     priority: 90,
-    score: (text: string) => keywordScore(text, ['saas', 'tenant', 'multi-tenant', 'org', 'workspace']),
+    score: (text: string) => keywordScore(
+      text,
+      ['saas', 'tenant', 'multi-tenant', 'org', 'workspace', 'dashboard', 'analytics', 'user management'],
+    ),
     traitMap: {
       route_shape: 'rest',
       verification: 'jwt-auth',

--- a/packages/scaffold-core/src/classify/patterns.ts
+++ b/packages/scaffold-core/src/classify/patterns.ts
@@ -41,6 +41,14 @@ export interface ScoredPatternDef extends PatternDef {
   traitMap: Record<string, string>;
 }
 
+// Payment-action keywords that independently trigger Payment Signal (and are
+// excluded from Webhook Signal so an explicit payment context always wins).
+// "billing" and "webhook" are deliberately NOT here: they only add to the
+// Payment Signal score as a bonus once one of these has already matched (see
+// Payment Signal's score() below) — listing them here would let bare
+// "billing" or "webhook" fire this pattern on their own again.
+const PAYMENT_ACTION_KEYWORDS = ['stripe', 'subscription', 'checkout', 'payment', 'payments'];
+
 export const SCORED_PATTERNS: ScoredPatternDef[] = [
   {
     name: 'worker' as PatternName,
@@ -73,15 +81,16 @@ export const SCORED_PATTERNS: ScoredPatternDef[] = [
     name: 'worker' as PatternName,
     status: 'ACTIVE',
     category: 'INTEGRATION',
-    keywords: ['stripe', 'billing', 'subscription', 'checkout', 'payment', 'payments', 'webhook'],
+    keywords: [...PAYMENT_ACTION_KEYWORDS, 'billing', 'webhook'],
     traits: ['post-handler', 'hmac-stripe', 'event-router', 'fetch-trigger'],
     signal: 'Payment Signal',
     priority: 100,
     score: (text: string) => {
-      // "billing" is intentionally excluded here — it appears in architectural contexts
-      // ("billing dashboard", "billing management") that are not Stripe webhook handlers.
-      // Require at least one explicit payment-action keyword before scoring billing terms.
-      const stripeHits = keywordScore(text, ['stripe', 'subscription', 'checkout', 'payment', 'payments']);
+      // "billing" is intentionally excluded from PAYMENT_ACTION_KEYWORDS — it appears in
+      // architectural contexts ("billing dashboard", "billing management") that are not
+      // Stripe webhook handlers. Require at least one explicit payment-action keyword
+      // before scoring billing terms.
+      const stripeHits = keywordScore(text, PAYMENT_ACTION_KEYWORDS);
       if (stripeHits === 0) return 0;
       return stripeHits + (text.includes('billing') ? 1 : 0) + (text.includes('webhook') ? 1 : 0);
     },
@@ -109,7 +118,7 @@ export const SCORED_PATTERNS: ScoredPatternDef[] = [
     score: (text: string) => {
       // Exclude only if explicit payment-action keywords are present (not "billing" alone —
       // see Payment Signal comment; "billing webhook" without Stripe is generic).
-      if (keywordScore(text, ['stripe', 'subscription', 'checkout', 'payment', 'payments']) >= 1) return 0;
+      if (keywordScore(text, PAYMENT_ACTION_KEYWORDS) >= 1) return 0;
       return keywordScore(text, ['webhook', 'signature verification', 'x-hub-signature', 'github webhook', 'slack webhook', 'twilio webhook']);
     },
     traitMap: {


### PR DESCRIPTION
## Summary
- Payment Signal's `score()` no longer treats `billing` alone as a Stripe signal — "billing dashboard" no longer misclassifies as a Stripe webhook handler. `billing` still counts when paired with another payment-action keyword (stripe/subscription/checkout/payment).
- Webhook Signal guard narrowed the same way so "billing webhook" (no Stripe) falls through to the generic webhook pattern instead of API fallback.
- SaaS Signal gains `dashboard`, `analytics`, and `user management` as scoring keywords so architectural intent outweighs a single vendor-name match.
- Bumps `scaffold-core` to 1.7.1.

## Test plan
- [x] 775/775 tests passing
- [x] New coverage in `classify.test.ts` for the billing/Stripe disambiguation cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)