### PR TITLE
docs: cross-link ai-playbook as conceptual grounding for ADF

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ This is a conflict in your existing dependency tree that npm surfaces while re-r
 
 A manifest declares modules, trigger keywords load them on demand, token budgets cap each one, and weighted sections tell the agent what matters.
 
+ADF operationalizes the Context Engineering principles documented in Stackbilt's [ai-playbook](https://github.com/Stackbilt-dev/ai-playbook).
+
 ```text
 .ai/
   manifest.adf    # Module registry: default vs on-demand with trigger keywords


### PR DESCRIPTION
Closes #250

Adds a single cross-link line in the "How ADF works" section of README.md noting that ADF operationalizes the Context Engineering principles documented in the ai-playbook repo. Additive only — no restructuring.