### PR TITLE
chore(deps): bump @types/node to 26.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "packageManager": "pnpm@9.15.9",
   "devDependencies": {
     "@stackbilt/cli": "workspace:*",
-    "@types/node": "^26.0.0",
+    "@types/node": "^26.1.2",
     "tsx": "^4.23.9",
     "typescript": "~5.8.2",
     "vite": "7.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: workspace:*
         version: link:packages/cli
       '@types/node':
-        specifier: ^26.0.0
-        version: 26.0.0
+        specifier: ^26.1.2
+        version: 26.2.0
       tsx:
         specifier: ^4.23.9
         version: 4.23.9
@@ -34,10 +34,10 @@ importers:
         version: 5.8.3
       vite:
         specifier: 7.3.5
-        version: 7.3.5(@types/node@26.0.0)(tsx@4.23.9)
+        version: 7.3.5(@types/node@26.2.0)(tsx@4.23.9)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@26.0.0)(vite@7.3.5(@types/node@26.0.0)(tsx@4.23.9))
+        version: 4.1.10(@types/node@26.2.0)(vite@7.3.5(@types/node@26.2.0)(tsx@4.23.9))
       zod:
         specifier: ^3.24.1
         version: 3.25.76
@@ -455,8 +455,8 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
-  '@types/node@26.0.0':
-    resolution: {integrity: sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==}
+  '@types/node@26.2.0':
+    resolution: {integrity: sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==}
 
   '@vitest/expect@4.1.10':
     resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
@@ -1241,7 +1241,7 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
-  '@types/node@26.0.0':
+  '@types/node@26.2.0':
     dependencies:
       undici-types: 8.3.0
 
@@ -1254,13 +1254,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(vite@7.3.5(@types/node@26.0.0)(tsx@4.23.9))':
+  '@vitest/mocker@4.1.10(vite@7.3.5(@types/node@26.2.0)(tsx@4.23.9))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.5(@types/node@26.0.0)(tsx@4.23.9)
+      vite: 7.3.5(@types/node@26.2.0)(tsx@4.23.9)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -1783,7 +1783,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@7.3.5(@types/node@26.0.0)(tsx@4.23.9):
+  vite@7.3.5(@types/node@26.2.0)(tsx@4.23.9):
     dependencies:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
@@ -1792,14 +1792,14 @@ snapshots:
       rollup: 4.62.0
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 26.0.0
+      '@types/node': 26.2.0
       fsevents: 2.3.3
       tsx: 4.23.9
 
-  vitest@4.1.10(@types/node@26.0.0)(vite@7.3.5(@types/node@26.0.0)(tsx@4.23.9)):
+  vitest@4.1.10(@types/node@26.2.0)(vite@7.3.5(@types/node@26.2.0)(tsx@4.23.9)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@7.3.5(@types/node@26.0.0)(tsx@4.23.9))
+      '@vitest/mocker': 4.1.10(vite@7.3.5(@types/node@26.2.0)(tsx@4.23.9))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -1816,10 +1816,10 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 7.3.5(@types/node@26.0.0)(tsx@4.23.9)
+      vite: 7.3.5(@types/node@26.2.0)(tsx@4.23.9)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 26.0.0
+      '@types/node': 26.2.0
     transitivePeerDependencies:
       - msw
 


### PR DESCRIPTION
Replacement for #270, recreated on current main after the tsx update. Verified with pnpm audit (0 vulnerabilities), build, and 60 test files / 859 tests.